### PR TITLE
Adapt for upcoming release of new INSPIRE version

### DIFF
--- a/app/src/main/java/com/chochitos/inspirehep_citations/InspireHEPApiService.kt
+++ b/app/src/main/java/com/chochitos/inspirehep_citations/InspireHEPApiService.kt
@@ -25,7 +25,7 @@ interface InspireHEPApiService {
             val retrofit = Retrofit.Builder()
                     .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
                     .addConverterFactory(GsonConverterFactory.create())
-                    .baseUrl("http://inspirehep.net/")
+                    .baseUrl("http://old.inspirehep.net/")
                     .build()
 
             return retrofit.create(InspireHEPApiService::class.java)


### PR DESCRIPTION
We will release the new INSPIRE version (currently at https://labs.inspirehep.net) as the main website on Monday. The old website will remain available at https://old.inspirehep.net for a couple of months. The new API is not 100% ready for public use, so this commit simply switches to the URL of the old website instead of using the new one.